### PR TITLE
add k-256 support

### DIFF
--- a/build/site/specifications/2.1/specs/C2PA_Specification.html
+++ b/build/site/specifications/2.1/specs/C2PA_Specification.html
@@ -3497,11 +3497,11 @@ Parenthetical notes in the lists below are explainers provided only as an aid to
 <div class="ulist">
 <ul>
 <li>
-<p>ECDSA requires elliptic curve keys on the P-256, P-384, or P-521 elliptic curves.</p>
+<p>ECDSA requires elliptic curve keys on the P-256, K-256, P-384, or P-521 elliptic curves.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>Although it is recommended to use P-256 keys with <code>ES256</code>, P-384 keys with <code>ES384</code>, and P-521 keys with <code>ES512</code>, it is not required. Implementations shall accept keys on any of these curves for all ECDSA algorithm choices.</p>
+<p>Although it is recommended to use P-256 or K-256 keys with <code>ES256</code>, P-384 keys with <code>ES384</code>, and P-521 keys with <code>ES512</code>, it is not required. Implementations shall accept keys on any of these curves for all ECDSA algorithm choices.</p>
 </li>
 </ul>
 </div>

--- a/build/site/specifications/2.1/specs/ContentCredentials.html
+++ b/build/site/specifications/2.1/specs/ContentCredentials.html
@@ -2705,11 +2705,11 @@ Parenthetical notes in the lists below are explainers provided only as an aid to
 <div class="ulist">
 <ul>
 <li>
-<p>ECDSA requires elliptic curve keys on the P-256, P-384, or P-521 elliptic curves.</p>
+<p>ECDSA requires elliptic curve keys on the P-256, K-256, P-384, or P-521 elliptic curves.</p>
 <div class="ulist">
 <ul>
 <li>
-<p>Although it is recommended to use P-256 keys with <code>ES256</code>, P-384 keys with <code>ES384</code>, and P-521 keys with <code>ES512</code>, it is not required. Implementations shall accept keys on any of these curves for all ECDSA algorithm choices.</p>
+<p>Although it is recommended to use P-256 or K-256 keys with <code>ES256</code>, P-384 keys with <code>ES384</code>, and P-521 keys with <code>ES512</code>, it is not required. Implementations shall accept keys on any of these curves for all ECDSA algorithm choices.</p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
[My PR for this on c2pa-rs](https://github.com/contentauth/c2pa-rs/pull/543) was closed because it's not part of the C2PA spec. Fair enough. If there's a better place to propose this change, please let me know.

My original post on the matter on Discord makes the pitch pretty well, I think:

> Curious if there are any feelings about adding `secp256k1`  (aka `ES256K` aka `k256` aka `NIST K-256`) signatures into the spec. Our use case is supporting Bluesky's AT Protocol, which requires both that and `p256`  aka `secp256r1` aka `prime256v1`) which is already supported. But it would also be nice to interoperate with hardware wallets and Ethereum-ecosystem crypto tools like Metamask.

> [...] an Aquareum node already has an Ethereum wallet keypair and identity associated with it, so signing segments with that same key would be the most straightforward way to implement it. Or as an end user you could validate that a piece of media is actually associated with iameli.eth or @iame.li on the AT Protocol.

> It would also facilitate integration with hardware wallets, which I contend are the best personal-use HSMs out there. As a content creator I'd love to sign each video I upload with my ledger that I already have around; it facilitates really strong personal key security.

> "Wasn't this going to be handled as part of the CAWG?" I don't think my use case is pertinent to the CAWG spec, though "attestations about crypto wallets" might be broadly within the CAWG's domain. But we're building an app (and OBS plugin) that allows users to broadcast signed livestreams from their devices. That makes us a claim generator, no? 
