### PR TITLE
Add Lunr search extension to Antora site

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -1,3 +1,6 @@
+antora:
+  extensions:
+  - '@antora/lunr-extension'
 site:
   title: C2PA Specifications
   url: https://c2pa.org/specifications
@@ -97,6 +100,41 @@ ui:
         font-size: 1.25rem;
         font-weight: 600;
         line-height: 1.2;
+      }
+      /* Search input styling */
+      .navbar-item.search {
+        position: relative;
+      }
+      #search-input {
+        box-sizing: border-box;
+        font-family: inherit;
+        font-size: inherit;
+        line-height: inherit;
+        color: inherit;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.3);
+        border-radius: 4px;
+        padding: 0.3em 0.5em;
+        width: 12em;
+        max-width: 100%;
+        transition: width 0.2s ease, border-color 0.2s ease;
+      }
+      #search-input:focus {
+        outline: none;
+        border-color: var(--color-brand-primary);
+        width: 18em;
+        max-width: calc(100vw - 4rem);
+      }
+      #search-input::placeholder {
+        color: rgba(0, 0, 0, 0.4);
+      }
+      @media screen and (max-width: 768px) {
+        #search-input {
+          width: 100%;
+        }
+        #search-input:focus {
+          width: 100%;
+        }
       }
   - path: img/C2PA-logo.svg
     contents: |
@@ -233,6 +271,13 @@ ui:
           </div>
           <div id="topbar-nav" class="navbar-menu">
             <div class="navbar-end">
+              {{#if env.SITE_SEARCH_PROVIDER}}
+              <div class="navbar-item search hide-for-print">
+                <div id="search-field" class="field">
+                  <input id="search-input" type="text" placeholder="Search the docs" aria-label="Search">
+                </div>
+              </div>
+              {{/if}}
               <div class="navbar-item has-dropdown is-hoverable">
                 <div class="navbar-link">Download</div>
                 <div class="navbar-dropdown">
@@ -283,6 +328,9 @@ ui:
           <p>Authored in AsciiDoc.<br>Produced by <a href="https://antora.org" target="_blank" rel="noopener">Antora</a> and <a href="https://asciidoctor.org" target="_blank" rel="noopener">Asciidoctor</a>.</p>
         </div>
       </footer>
+      {{#if env.SITE_SEARCH_PROVIDER}}
+      {{> search-scripts}}
+      {{/if}}
 asciidoc:
   extensions:
   - asciidoctor-kroki

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,3 +1,6 @@
+antora:
+  extensions:
+  - '@antora/lunr-extension'
 site:
   title: C2PA Specifications
   url: https://c2pa.org/specifications
@@ -99,6 +102,41 @@ ui:
       .doc h6 {
         font-size: 0.85rem;
         font-weight: 600;
+      }
+      /* Search input styling */
+      .navbar-item.search {
+        position: relative;
+      }
+      #search-input {
+        box-sizing: border-box;
+        font-family: inherit;
+        font-size: inherit;
+        line-height: inherit;
+        color: inherit;
+        background: #fff;
+        border: 1px solid rgba(0, 0, 0, 0.3);
+        border-radius: 4px;
+        padding: 0.3em 0.5em;
+        width: 12em;
+        max-width: 100%;
+        transition: width 0.2s ease, border-color 0.2s ease;
+      }
+      #search-input:focus {
+        outline: none;
+        border-color: var(--color-brand-primary);
+        width: 18em;
+        max-width: calc(100vw - 4rem);
+      }
+      #search-input::placeholder {
+        color: rgba(0, 0, 0, 0.4);
+      }
+      @media screen and (max-width: 768px) {
+        #search-input {
+          width: 100%;
+        }
+        #search-input:focus {
+          width: 100%;
+        }
       }
   - path: img/C2PA-logo.svg
     contents: |
@@ -235,6 +273,13 @@ ui:
           </div>
           <div id="topbar-nav" class="navbar-menu">
             <div class="navbar-end">
+              {{#if env.SITE_SEARCH_PROVIDER}}
+              <div class="navbar-item search hide-for-print">
+                <div id="search-field" class="field">
+                  <input id="search-input" type="text" placeholder="Search the docs" aria-label="Search">
+                </div>
+              </div>
+              {{/if}}
               <div class="navbar-item has-dropdown is-hoverable">
                 <div class="navbar-link">Download</div>
                 <div class="navbar-dropdown">
@@ -285,6 +330,9 @@ ui:
           <p>Authored in AsciiDoc.<br>Produced by <a href="https://antora.org" target="_blank" rel="noopener">Antora</a> and <a href="https://asciidoctor.org" target="_blank" rel="noopener">Asciidoctor</a>.</p>
         </div>
       </footer>
+      {{#if env.SITE_SEARCH_PROVIDER}}
+      {{> search-scripts}}
+      {{/if}}
 asciidoc:
   extensions:
   - asciidoctor-kroki

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "antora": "3.1.14"
   },
   "dependencies": {
+    "@antora/lunr-extension": "1.0.0-alpha.13",
     "asciidoctor": "^3.0.4",
     "asciidoctor-kroki": "^0.18.1"
   }


### PR DESCRIPTION
The specification site has no search functionality. This adds the @antora/lunr-extension to package.json and both the production and local Antora playbooks, enabling full-text search across the published specifications.

Fixes #65