### PR TITLE
feat: replace Lunr with Pagefind for version-aware site search

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,22 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      # automated publishing takes too long so turning off...
-      # - name: Run Antora
-      #   uses: kameshsampath/antora-site-action@v0.2.4
-      #   with:
-      #     antora_playbook: antora-playbook.yml
-      #     antora_generator: 'antora-site-generator-lunr'
-      #     antora_docsearch_enabled: 'true'
-      # - name: Install Node.js
-      #   uses: actions/setup-node@v2
-      #   with:
-      #     node-version: '14'
-      # - name: Install Antora
-      #   run: npm i --no-optional --silent @antora/cli@2.3.4 @antora/site-generator-default@2.3.4 asciidoctor-kroki
-      # - name: Run Antora
-      #   run: $(npm bin)/antora --fetch antora-playbook.yml
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npx antora --fetch antora-playbook.yml
+      - name: Build Pagefind index
+        run: npx pagefind --site build/site
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -1,6 +1,3 @@
-antora:
-  extensions:
-  - '@antora/lunr-extension'
 site:
   title: C2PA Specifications
   url: https://spec.c2pa.org/specifications
@@ -122,41 +119,6 @@ ui:
         font-weight: 600;
         line-height: 1.2;
       }
-      /* Search input styling */
-      .navbar-item.search {
-        position: relative;
-      }
-      #search-input {
-        box-sizing: border-box;
-        font-family: inherit;
-        font-size: inherit;
-        line-height: inherit;
-        color: #000;
-        background: #fff;
-        border: 1px solid rgba(0, 0, 0, 0.3);
-        border-radius: 4px;
-        padding: 0.3em 0.5em;
-        width: 12em;
-        max-width: 100%;
-        transition: width 0.2s ease, border-color 0.2s ease;
-      }
-      #search-input:focus {
-        outline: none;
-        border-color: var(--color-brand-primary);
-        width: 18em;
-        max-width: calc(100vw - 4rem);
-      }
-      #search-input::placeholder {
-        color: rgba(0, 0, 0, 0.4);
-      }
-      @media screen and (max-width: 768px) {
-        #search-input {
-          width: 100%;
-        }
-        #search-input:focus {
-          width: 100%;
-        }
-      }
   - path: img/C2PA-logo.svg
     contents: |
       <?xml version="1.0" encoding="utf-8"?>
@@ -274,6 +236,20 @@ ui:
       <link rel="stylesheet" href="{{{uiRootPath}}}/css/c2pa-branding.css">
       <link rel="icon" type="image/svg+xml" sizes="any" href="{{{uiRootPath}}}/img/C2PA-favicon.svg">
       <link rel="mask-icon" href="{{{uiRootPath}}}/img/C2PA-logo.svg" color="#e40046">
+      <link rel="stylesheet" href="{{{siteRootPath}}}/_pagefind/pagefind-ui.css">
+  - path: partials/head-scripts.hbs
+    contents: |
+      <script src="{{{siteRootPath}}}/_pagefind/pagefind-ui.js"></script>
+      <script>
+        window.addEventListener('DOMContentLoaded', function () {
+          new PagefindUI({
+            element: '#search',
+            showImages: false,
+            excerptLength: 15,
+            resetStyles: false
+          });
+        });
+      </script>
   - path: partials/edit-this-page.hbs
     contents: |
       
@@ -292,13 +268,9 @@ ui:
           </div>
           <div id="topbar-nav" class="navbar-menu">
             <div class="navbar-end">
-              {{#if env.SITE_SEARCH_PROVIDER}}
-              <div class="navbar-item search hide-for-print">
-                <div id="search-field" class="field">
-                  <input id="search-input" type="text" placeholder="Search the docs" aria-label="Search">
-                </div>
+              <div class="navbar-item hide-for-print">
+                <div id="search"></div>
               </div>
-              {{/if}}
               <div class="navbar-item has-dropdown is-hoverable">
                 <div class="navbar-link">Download</div>
                 <div class="navbar-dropdown">
@@ -323,6 +295,7 @@ ui:
           </div>
         </nav>
       </header>
+      <span hidden data-pagefind-filter="version:{{page.componentVersion}}"></span>
   - path: partials/footer-content.hbs
     contents: |
       <footer class="footer">
@@ -349,9 +322,6 @@ ui:
           <p>Authored in AsciiDoc.<br>Produced by <a href="https://antora.org" target="_blank" rel="noopener">Antora</a> and <a href="https://asciidoctor.org" target="_blank" rel="noopener">Asciidoctor</a>.</p>
         </div>
       </footer>
-      {{#if env.SITE_SEARCH_PROVIDER}}
-      {{> search-scripts}}
-      {{/if}}
 asciidoc:
   extensions:
   - asciidoctor-kroki

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,6 +1,3 @@
-antora:
-  extensions:
-  - '@antora/lunr-extension'
 site:
   title: C2PA Specifications
   url: https://spec.c2pa.org/specifications
@@ -125,41 +122,6 @@ ui:
         font-size: 0.85rem;
         font-weight: 600;
       }
-      /* Search input styling */
-      .navbar-item.search {
-        position: relative;
-      }
-      #search-input {
-        box-sizing: border-box;
-        font-family: inherit;
-        font-size: inherit;
-        line-height: inherit;
-        color: #000;
-        background: #fff;
-        border: 1px solid rgba(0, 0, 0, 0.3);
-        border-radius: 4px;
-        padding: 0.3em 0.5em;
-        width: 12em;
-        max-width: 100%;
-        transition: width 0.2s ease, border-color 0.2s ease;
-      }
-      #search-input:focus {
-        outline: none;
-        border-color: var(--color-brand-primary);
-        width: 18em;
-        max-width: calc(100vw - 4rem);
-      }
-      #search-input::placeholder {
-        color: rgba(0, 0, 0, 0.4);
-      }
-      @media screen and (max-width: 768px) {
-        #search-input {
-          width: 100%;
-        }
-        #search-input:focus {
-          width: 100%;
-        }
-      }
   - path: img/C2PA-logo.svg
     contents: |
       <?xml version="1.0" encoding="utf-8"?>
@@ -277,6 +239,20 @@ ui:
       <link rel="stylesheet" href="{{{uiRootPath}}}/css/c2pa-branding.css">
       <link rel="icon" type="image/svg+xml" sizes="any" href="{{{uiRootPath}}}/img/C2PA-favicon.svg">
       <link rel="mask-icon" href="{{{uiRootPath}}}/img/C2PA-logo.svg" color="#e40046">
+      <link rel="stylesheet" href="{{{siteRootPath}}}/_pagefind/pagefind-ui.css">
+  - path: partials/head-scripts.hbs
+    contents: |
+      <script src="{{{siteRootPath}}}/_pagefind/pagefind-ui.js"></script>
+      <script>
+        window.addEventListener('DOMContentLoaded', function () {
+          new PagefindUI({
+            element: '#search',
+            showImages: false,
+            excerptLength: 15,
+            resetStyles: false
+          });
+        });
+      </script>
   - path: partials/edit-this-page.hbs
     contents: |
       
@@ -295,13 +271,9 @@ ui:
           </div>
           <div id="topbar-nav" class="navbar-menu">
             <div class="navbar-end">
-              {{#if env.SITE_SEARCH_PROVIDER}}
-              <div class="navbar-item search hide-for-print">
-                <div id="search-field" class="field">
-                  <input id="search-input" type="text" placeholder="Search the docs" aria-label="Search">
-                </div>
+              <div class="navbar-item hide-for-print">
+                <div id="search"></div>
               </div>
-              {{/if}}
               <div class="navbar-item has-dropdown is-hoverable">
                 <div class="navbar-link">Download</div>
                 <div class="navbar-dropdown">
@@ -326,6 +298,7 @@ ui:
           </div>
         </nav>
       </header>
+      <span hidden data-pagefind-filter="version:{{page.componentVersion}}"></span>
   - path: partials/footer-content.hbs
     contents: |
       <footer class="footer">
@@ -352,9 +325,6 @@ ui:
           <p>Authored in AsciiDoc.<br>Produced by <a href="https://antora.org" target="_blank" rel="noopener">Antora</a> and <a href="https://asciidoctor.org" target="_blank" rel="noopener">Asciidoctor</a>.</p>
         </div>
       </footer>
-      {{#if env.SITE_SEARCH_PROVIDER}}
-      {{> search-scripts}}
-      {{/if}}
 asciidoc:
   extensions:
   - asciidoctor-kroki

--- a/buildsite-local.sh
+++ b/buildsite-local.sh
@@ -11,3 +11,6 @@ WITH_KROKI=danyill/antora-kroki:latest
 docker run -u $(id -u) -v $PWD:/antora:Z \
 			--rm -t "${WITH_KROKI}" \
 			--cache-dir=./.cache/antora antora-playbook-local.yml
+
+# build pagefind index over rendered output
+npx pagefind --site build/site

--- a/buildsite.sh
+++ b/buildsite.sh
@@ -11,3 +11,6 @@ WITH_KROKI=danyill/antora-kroki:latest
 docker run -u $(id -u) -v $PWD:/antora:Z \
 			--rm -t "${WITH_KROKI}" \
 			--cache-dir=./.cache/antora antora-playbook.yml
+
+# build pagefind index over rendered output
+npx pagefind --site build/site

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "antora": "3.1.14"
+    "antora": "3.1.14",
+    "pagefind": "^1.3.0"
   },
   "dependencies": {
-    "@antora/lunr-extension": "1.0.0-alpha.13",
     "asciidoctor": "^3.0.4",
     "asciidoctor-kroki": "^0.18.1"
   }


### PR DESCRIPTION
Closes #120.

`@antora/lunr-extension` indexes every component version with no version awareness, so near-identical text across spec versions produces near-tied scores that fall back to index order rather than recency. This replaces it with Pagefind.

Each rendered page is tagged with a hidden `<span data-pagefind-filter="version:<ver>">` injected via `header-content.hbs`, giving Pagefind a version facet the user can filter on. The old `#search-input` element (gated on `SITE_SEARCH_PROVIDER`) is replaced by a PagefindUI widget loaded from the self-hosted `/_pagefind/` directory Pagefind writes after the build. The now-unused Lunr search CSS is removed from `c2pa-branding.css`.

`npx pagefind --site build/site` is added after the Antora step in both shell build scripts and the GitHub Actions publish workflow. The publish workflow is also updated to Node 20 and actions v4, with the Antora build steps re-enabled.